### PR TITLE
Rename Collab Space to Working Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Open Visualization Collaboration Space
+# Open Visualization Working Group
 
-The Open Visualization Collaboration Space “OpenVis” is a forum within the OpenJS Foundation to neutrally govern comprehensive and widely adopted visualization libraries based on JavaScript and WebGL.
+The Open Visualization Working Group “OpenVis” is a forum within the OpenJS Foundation to neutrally govern comprehensive and widely adopted visualization libraries based on JavaScript and WebGL.
 
 Members of OpenVis help other developers, data scientists, and visualization specialists improve GPU-accelerated visualization software. We do this through an open governance model that encourages participation and technical contribution, and by providing a framework for long term stewardship by a variety of stakeholders. Check out [our membership page](https://github.com/openjs-foundation/openvis-collab-space/blob/main/join.md) if you're interested in becoming a member.
 
@@ -22,7 +22,7 @@ The purpose of this repository is to provide a central place for coordination an
 
 Interested parties can also [join our #open-visualization channel](https://communityinviter.com/apps/js-foundation/join-openjs-foundation-on-slack) on Slack.
 
-## Collaboration Space Members
+## Working Group Members
 
 * Chris Gervang ([@chrisgervang](https://github.com/chrisgervang))
 * Ib Green ([@ibgreen](https://github.com/ibgreen))

--- a/contribute.md
+++ b/contribute.md
@@ -1,4 +1,4 @@
-# Contribute your project to the Open Visualization Collaboration Space
+# Contribute your project to the Open Visualization Working Group
 
 ## Under Construction
 This page is currently under construction. Please check back soon for updates.

--- a/join.md
+++ b/join.md
@@ -1,4 +1,4 @@
-# Joining the Open Visualization Collaboration Space
+# Joining the Open Visualization Working Group
 
 ## Under Construction
 This page is currently under construction. Please check back soon for updates.

--- a/media.md
+++ b/media.md
@@ -1,4 +1,4 @@
-# Open Visualization Collaboration Space Media
+# Open Visualization Working Group Media
 
 ## Under Construction
 This page is currently under construction. Please check back soon for updates.
@@ -6,4 +6,4 @@ This page is currently under construction. Please check back soon for updates.
 [Open Visualization Collaborations Summit 2022 Youtube Playlist](https://www.youtube.com/watch?v=txQ7G98qUOg&list=PLyspMSh4XhLMOlAOLMNdT2wjtTMlqFAwo)
 
 
-[Open Visualization Collaboration Space BiWeekly Playlists](https://www.youtube.com/watch?v=iUgFxv3U3Sc&list=PLyspMSh4XhLO7-iz8YFabD92h_85bw4SG&index=1)
+[Open Visualization Working Group BiWeekly Playlists](https://www.youtube.com/watch?v=iUgFxv3U3Sc&list=PLyspMSh4XhLO7-iz8YFabD92h_85bw4SG&index=1)

--- a/meetings/OpenVis-minutes-2022-1-19.md
+++ b/meetings/OpenVis-minutes-2022-1-19.md
@@ -1,4 +1,4 @@
-# Meeting Minutes: Open Visualization Collaboration Space
+# Meeting Minutes: Open Visualization Working Group
 Date: January 19, 2023
 
 ## Agenda


### PR DESCRIPTION
## Summary
- Renamed all references of "Collaboration Space" to "Working Group" across all documentation files
- Updated README.md, contribute.md, join.md, media.md, and meeting minutes

Per CPC decision to standardize terminology across the OpenJS Foundation. Closes #5.

## Files changed
- `README.md` — title, description, and members section heading
- `contribute.md` — page title
- `join.md` — page title
- `media.md` — page title and playlist link text
- `meetings/OpenVis-minutes-2022-1-19.md` — meeting minutes title

> Note: GitHub repo URLs (`openvis-collab-space`) are left as-is since they point to the current repo slug. A repo rename would be a separate admin action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)